### PR TITLE
feat: load specialties in doctor registration

### DIFF
--- a/Frontend/componentes/auth/Registro.js
+++ b/Frontend/componentes/auth/Registro.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   KeyboardAvoidingView,
   Platform
 } from 'react-native'
+import { Picker } from '@react-native-picker/picker'
 
 export default function Register({ navigation }) {
   const [userType, setUserType] = useState('') // 'paciente' o 'doctor'
@@ -26,6 +27,22 @@ export default function Register({ navigation }) {
   // Campos doctor
   const [matricula, setMatricula] = useState('')
   const [especialidad, setEspecialidad] = useState('')
+  const [especialidades, setEspecialidades] = useState([])
+
+  useEffect(() => {
+    if (userType === 'doctor') {
+      const fetchEspecialidades = async () => {
+        try {
+          const response = await fetch('http://localhost:3000/api/especialidades')
+          const data = await response.json()
+          setEspecialidades(data)
+        } catch (error) {
+          console.error('Error al obtener especialidades', error)
+        }
+      }
+      fetchEspecialidades()
+    }
+  }, [userType])
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
@@ -156,8 +173,22 @@ export default function Register({ navigation }) {
 
         {userType === 'doctor' && (
           <>
-            <TextInput placeholder="Matrícula" value={matricula} onChangeText={setMatricula} style={styles.input} />
-            <TextInput placeholder="Especialidad" value={especialidad} onChangeText={setEspecialidad} style={styles.input} />
+            <TextInput
+              placeholder="Matrícula"
+              value={matricula}
+              onChangeText={setMatricula}
+              style={styles.input}
+            />
+            <Picker
+              selectedValue={especialidad}
+              onValueChange={(itemValue) => setEspecialidad(itemValue)}
+              style={styles.picker}
+            >
+              <Picker.Item label="Seleccioná una especialidad" value="" />
+              {especialidades.map((esp) => (
+                <Picker.Item key={esp.id} label={esp.nombre} value={esp.nombre} />
+              ))}
+            </Picker>
           </>
         )}
 
@@ -250,6 +281,15 @@ const styles = StyleSheet.create({
     marginVertical:8,
     fontSize:16,
     fontWeight:'400'
+  },
+  picker: {
+    width: '100%',
+    height: 50,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 10,
+    marginVertical: 8,
+    justifyContent: 'center',
   },
   button: {
     width:'100%',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~5.0.4",
+        "@react-native-picker/picker": "^2.7.5",
         "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
@@ -2120,6 +2121,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.7.5.tgz",
+      "integrity": "sha512-vhMaOLkXSUb+YKVbukMJToU4g+89VMhBG2U9+cLYF8X8HtFRidrHjohGqT8/OyesDuKIXeLIP+UFYI9Q9CRA9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
+    "@react-native-picker/picker": "^2.7.5",
     "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",


### PR DESCRIPTION
## Summary
- fetch specialties from backend and display in doctor registration
- add picker dependency for selecting specialties

## Testing
- `npm test` (fails: Missing script "test")
- `cd Backend && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b18ef64834832e8ff0392a1dd5c30c