### PR TITLE
Implement Supabase-based login and registration

### DIFF
--- a/Frontend/componentes/auth/Login.js
+++ b/Frontend/componentes/auth/Login.js
@@ -11,32 +11,22 @@ export default function Login({ navigation }) {
 
   const handleLogin = async () => {
     setLoading(true)
-    setError(null) //no se siguen mostrando errores anteriores
+    setError(null) // no se siguen mostrando errores anteriores
 
-    try{
-      const response = await fetch('',{
-      method: 'POST',
-      Headers: {},
-      body: JSON.stringify({
+    try {
+      const { error: loginError } = await supabase.auth.signInWithPassword({
         email,
         password,
-      }),
-  })
+      })
+      if (loginError) throw loginError
 
-    const data = await response.json()
-  
-    if (response.ok) {
-      // redirige a la home, pero todavia no esta hecha
-      navigation.replace('')
-    } else {
-      setError(data.message || 'Error desconocido')
+      navigation.replace('Home')
+    } catch (err) {
+      setError(err.message || 'Error de conexión, intenta nuevamente')
+    } finally {
+      setLoading(false)
     }
-  } catch (err) {
-    setError('Error de conexión, intenta nuevamente')
-  } finally {
-    setLoading(false)
   }
-}
 
   return (
     <View style={styles.container}>

--- a/Frontend/utils/supabaseClient.js
+++ b/Frontend/utils/supabaseClient.js
@@ -1,6 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
 
 const SUPABASE_URL = 'https://qhtjlctnsoajgouinjaq.supabase.co' // la URL real
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFodGpsY3Ruc29hamdvdWluamFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkwMzU2NjMsImV4cCI6MjA2NDYxMTY2M30.AVpXetLCSZLG_hg0W4wSJGVvXuwaIiwo983QZZAshI8'   // tu clave pública real
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFodGpsY3Ruc29hamdvdWluamFxIiwi' +
+  'Y3JvbGUiOiJhbm9uIiwiaWF0IjoxNzQ5MDM1NjYzLCJleHAiOjIwNjQ2MTE2NjN9.AVpXetLCSZLG_hg0W4wSJGVvXuwaIiwo983QZZAshI8' // tu clave pública real
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+


### PR DESCRIPTION
## Summary
- Hook up login to Supabase and navigate to home on success
- Register users with Supabase, send profile data to correct API endpoint and use selected specialty IDs
- Fix Supabase client configuration string

## Testing
- `npm test`
- `npm test --prefix Backend`


------
https://chatgpt.com/codex/tasks/task_e_68b192dcd4a0832ebae58d13df25f766