### PR TITLE
Fix registration and login flows with profile loading

### DIFF
--- a/Backend/controllers/pacientes-controller.js
+++ b/Backend/controllers/pacientes-controller.js
@@ -32,6 +32,20 @@ router.get('/:id', async (req, res) => {
   }
 });
 
+router.get('/usuario/:usuarioId', async (req, res) => {
+  const usuarioId = req.params.usuarioId;
+  try {
+    const returnEntity = await currentService.getByUsuarioIdAsync(usuarioId);
+    if (returnEntity != null) {
+      res.status(StatusCodes.OK).json(returnEntity);
+    } else {
+      res.status(StatusCodes.NOT_FOUND).send(`No se encontro la entidad (usuario_id:${usuarioId}).`);
+    }
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).send('Error interno.');
+  }
+});
+
 router.post('', async (req, res) => {
   try {
     const entity = req.body;

--- a/Backend/controllers/profesionales-controller.js
+++ b/Backend/controllers/profesionales-controller.js
@@ -32,6 +32,20 @@ router.get('/:id', async (req, res) => {
   }
 });
 
+router.get('/email/:email', async (req, res) => {
+  const email = req.params.email;
+  try {
+    const returnEntity = await currentService.getByEmailAsync(email);
+    if (returnEntity != null) {
+      res.status(StatusCodes.OK).json(returnEntity);
+    } else {
+      res.status(StatusCodes.NOT_FOUND).send(`No se encontro la entidad (email:${email}).`);
+    }
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).send('Error interno.');
+  }
+});
+
 router.post('', async (req, res) => {
   try {
     const entity = req.body;

--- a/Backend/repositories/pacientes-repository.js
+++ b/Backend/repositories/pacientes-repository.js
@@ -49,6 +49,22 @@ export default class PacientesRepository {
         return returnEntity;
     }
 
+    getByUsuarioIdAsync = async (usuarioId) => {
+        console.log(`PacientesRepository.getByUsuarioIdAsync(${usuarioId})`);
+        let returnEntity = null;
+        try {
+            const sql = `SELECT * FROM pacientes WHERE usuario_id=$1`;
+            const values = [usuarioId];
+            const resultPg = await this.getDBPool().query(sql, values);
+            if (resultPg.rows.length > 0) {
+                returnEntity = resultPg.rows[0];
+            }
+        } catch (error) {
+            LogHelper.logError(error);
+        }
+        return returnEntity;
+    }
+
     // Crear paciente
     createAsync = async (entity) => {
         console.log(`PacientesRepository.createAsync(${JSON.stringify(entity)})`);

--- a/Backend/repositories/profesionales-repository.js
+++ b/Backend/repositories/profesionales-repository.js
@@ -39,12 +39,28 @@ export default class ProfesionalesRepository {
             const sql = `SELECT * FROM profesionales WHERE id=$1`;
             const values = [id];
             const resultPg = await this.getDBPool().query(sql, values);
-            if (resultPg.rows.length > 0){
+            if (resultPg.rows.length > 0) {
                 returnEntity = resultPg.rows[0];
             }
         } catch (error) {
             LogHelper.logError(error);
-        } 
+        }
+        return returnEntity;
+    }
+
+    getByEmailAsync = async (email) => {
+        console.log(`ProfesionalesRepository.getByEmailAsync(${email})`);
+        let returnEntity = null;
+        try {
+            const sql = `SELECT * FROM profesionales WHERE email=$1`;
+            const values = [email];
+            const resultPg = await this.getDBPool().query(sql, values);
+            if (resultPg.rows.length > 0) {
+                returnEntity = resultPg.rows[0];
+            }
+        } catch (error) {
+            LogHelper.logError(error);
+        }
         return returnEntity;
     }
 
@@ -53,31 +69,26 @@ export default class ProfesionalesRepository {
         let newId = 0;
 
         try {
-            /*
-            INSERT INTO "public"."profesionales" 
-	("id", "nombre_completo", "matricula", "especialidad", "telefono", "id_especialidad") 
-VALUES 
-	('3', 'Pablo', '32132132', 'eliminar este ampo', '1114444', '1');
-            */
             const sql = ` INSERT INTO profesionales (
-                            nombre_completo         , 
-                            matricula               , 
-                 
-                            telefono                , 
-                            id_especialidad
+                            nombre_completo,
+                            matricula,
+                            telefono,
+                            id_especialidad,
+                            email
                         ) VALUES (
-                            $1, 
-                            $2, 
-                            $3, 
-                            $4
-                     
+                            $1,
+                            $2,
+                            $3,
+                            $4,
+                            $5
                         ) RETURNING id`;
-            const values =  [   entity?.nombre_completo         ?? '', 
-                                entity?.matricula               ?? '', 
-                                entity?.telefono                ?? '', 
-                                entity?.id_
-                                         ?? null
-                            ];
+            const values = [
+                entity?.nombre_completo ?? '',
+                entity?.matricula ?? '',
+                entity?.telefono ?? '',
+                entity?.id_especialidad ?? null,
+                entity?.email ?? null
+            ];
             const resultPg = await this.getDBPool().query(sql, values);
             newId = resultPg.rows[0].id;
         } catch (error) {
@@ -89,28 +100,27 @@ VALUES
     updateAsync = async (entity) => {
         console.log(`ProfesionalesRepository.updateAsync(${JSON.stringify(entity)})`);
         let rowsAffected = 0;
-        let id = entity.id;
-        
+        const id = entity.id;
+
         try {
             const previousEntity = await this.getByIdAsync(id);
-            if (previousEntity== null) return 0;
-            const sql = `UPDATE profesionales SET 
-                            nombre              = $2, 
-                            apellido            = $3, 
-                            id_curso            = $4, 
-                            fecha_nacimiento    = $5, 
-                            hace_deportes       = $6
+            if (previousEntity == null) return 0;
+            const sql = `UPDATE profesionales SET
+                            nombre_completo = $2,
+                            matricula = $3,
+                            telefono = $4,
+                            id_especialidad = $5,
+                            email = $6
                         WHERE id = $1`;
-                            
-            const values =  [   id,     // $1
-                                entity?.nombre              ?? previousEntity?.nombre, 
-                                entity?.apellido            ?? previousEntity?.apellido, 
-                                entity?.id_curso            ?? previousEntity?.id_curso, 
-                                entity?.fecha_nacimiento    ?? previousEntity?.fecha_nacimiento, 
-                                entity?.hace_deportes       ?? previousEntity?.hace_deportes
-                            ];
+            const values = [
+                id,
+                entity?.nombre_completo ?? previousEntity?.nombre_completo,
+                entity?.matricula ?? previousEntity?.matricula,
+                entity?.telefono ?? previousEntity?.telefono,
+                entity?.id_especialidad ?? previousEntity?.id_especialidad,
+                entity?.email ?? previousEntity?.email
+            ];
             const resultPg = await this.getDBPool().query(sql, values);
-
             rowsAffected = resultPg.rowCount;
         } catch (error) {
             LogHelper.logError(error);
@@ -133,33 +143,3 @@ VALUES
         return rowsAffected;
     }
 }
-/*
-Este operador (??) retorna el lado derecho de la operación cuando el lado izquierdo es un valor falsy.
-
-falsy es un valor que se considera false (false). 
-En Javascript existen sólo 6 valores falsy: undefined, null, NaN, 0, "" (string vacio) y false.
-
-console.log(12 || "not found") // 12
-console.log(0  || "not found") // "not found"
-
-console.log("jane" || "not found") // "jane"
-console.log(""     || "not found") // "not found"
-
-console.log(true  || "not found") // true
-console.log(false || "not found") // "not found"
-
-console.log(undefined || "not found") // "not found"
-console.log(null      || "not found") // "not found"
-----------------------------------------------------
-console.log(12 ?? "not found") // 12
-console.log(0  ?? "not found") // 0
-
-console.log("jane" ?? "not found") // "jane"
-console.log(""     ?? "not found") // ""
-
-console.log(true  ?? "not found") // true
-console.log(false ?? "not found") // false
-
-console.log(undefined ?? "not found") // "not found"
-console.log(null      ?? "not found") // "not found"
-*/

--- a/Backend/services/pacientes-service.js
+++ b/Backend/services/pacientes-service.js
@@ -18,6 +18,12 @@ export default class PacientesService {
         return returnEntity;
     }
 
+    getByUsuarioIdAsync = async (usuarioId) => {
+        console.log(`PacientesService.getByUsuarioIdAsync(${usuarioId})`);
+        const returnEntity = await this.PacientesRepository.getByUsuarioIdAsync(usuarioId);
+        return returnEntity;
+    }
+
     createAsync = async (entity) => {
         console.log(`PacientesService.createAsync(${JSON.stringify(entity)})`);
         const rowsAffected = await this.PacientesRepository.createAsync(entity);

--- a/Backend/services/profesionales-service.js
+++ b/Backend/services/profesionales-service.js
@@ -18,6 +18,12 @@ export default class ProfesionalesService {
         return returnEntity;
     }
 
+    getByEmailAsync = async (email) => {
+        console.log(`ProfesionalesService.getByEmailAsync(${email})`);
+        const returnEntity = await this.ProfesionalesRepository.getByEmailAsync(email);
+        return returnEntity;
+    }
+
     createAsync = async (entity) => {
         console.log(`ProfesionalesService.createAsync(${JSON.stringify(entity)})`);
         const rowsAffected = await this.ProfesionalesRepository.createAsync(entity);
@@ -35,12 +41,4 @@ export default class ProfesionalesService {
         const rowsAffected = await this.ProfesionalesRepository.deleteByIdAsync(id);
         return rowsAffected;
     }
-
-    /*
-    getByIdAsync_PPT = async (id) => {
-        console.log('Estoy en: ProfesionalesService.getByIdAsync_PPT()');
-        const returnEntity = await this.ProfesionalesRepository.getByIdAsync_PPT(id);
-        return returnEntity;
-    }
-    */
 }

--- a/Frontend/componentes/Home/HomeScreen.js
+++ b/Frontend/componentes/Home/HomeScreen.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { supabase } from '../../utils/supabaseClient'
 
-export default function HomeScreen({ navigation }) {
+export default function HomeScreen({ route, navigation }) {
+  const { user, userType } = route.params || {}
+
   const handleLogout = async () => {
     await supabase.auth.signOut()
     navigation.replace('Login')
@@ -10,18 +12,18 @@ export default function HomeScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Bienvenido a MedUp</Text>
+      <Text style={styles.title}>Bienvenido {user?.nombre_completo || ''}</Text>
       <Text style={styles.subtitle}>Tu app para gestión médica</Text>
 
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Info')}>
         <Text style={styles.buttonText}>Información</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Profile')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Profile', { user, userType })}>
         <Text style={styles.buttonText}>Mi Perfil</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={[styles.button, {backgroundColor: '#e74c3c'}]} onPress={handleLogout}>
+      <TouchableOpacity style={[styles.button, { backgroundColor: '#e74c3c' }]} onPress={handleLogout}>
         <Text style={styles.buttonText}>Cerrar sesión</Text>
       </TouchableOpacity>
     </View>

--- a/Frontend/componentes/Profile/ProfileScreen.js
+++ b/Frontend/componentes/Profile/ProfileScreen.js
@@ -1,33 +1,8 @@
-import React, { useEffect, useState } from 'react'
-import { View, Text, StyleSheet, ActivityIndicator } from 'react-native'
-import { supabase } from '../../utils/supabaseClient'
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
 
-export default function ProfileScreen() {
-  const [user, setUser] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const getUser = async () => {
-      const currentUser = supabase.auth.getUser()
-      const { data, error } = await supabase.auth.getUser()
-
-      if (error) {
-        setUser(null)
-      } else {
-        setUser(data.user)
-      }
-      setLoading(false)
-    }
-    getUser()
-  }, [])
-
-  if (loading) {
-    return (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" color="#1A1A6E" />
-      </View>
-    )
-  }
+export default function ProfileScreen({ route }) {
+  const { user, userType } = route.params || {}
 
   if (!user) {
     return (
@@ -40,11 +15,21 @@ export default function ProfileScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Mi Perfil</Text>
-      <Text style={styles.label}>Email:</Text>
-      <Text style={styles.text}>{user.email}</Text>
-
-      {/* Podés agregar más campos del perfil que tengas en Supabase */}
-
+      <Text style={styles.label}>Nombre:</Text>
+      <Text style={styles.text}>{user.nombre_completo}</Text>
+      {userType === 'paciente' ? (
+        <>
+          <Text style={styles.label}>DNI:</Text>
+          <Text style={styles.text}>{user.dni}</Text>
+        </>
+      ) : (
+        <>
+          <Text style={styles.label}>Matrícula:</Text>
+          <Text style={styles.text}>{user.matricula}</Text>
+        </>
+      )}
+      <Text style={styles.label}>Teléfono:</Text>
+      <Text style={styles.text}>{user.telefono}</Text>
     </View>
   )
 }

--- a/Frontend/componentes/auth/Login.js
+++ b/Frontend/componentes/auth/Login.js
@@ -11,16 +11,30 @@ export default function Login({ navigation }) {
 
   const handleLogin = async () => {
     setLoading(true)
-    setError(null) // no se siguen mostrando errores anteriores
+    setError(null)
 
     try {
-      const { error: loginError } = await supabase.auth.signInWithPassword({
+      const { data, error: loginError } = await supabase.auth.signInWithPassword({
         email,
         password,
       })
       if (loginError) throw loginError
 
-      navigation.replace('Home')
+      const userId = data.user?.id
+      let userType = 'paciente'
+      let profileRes = await fetch(`http://localhost:3000/api/pacientes/usuario/${userId}`)
+      let profile
+      if (profileRes.ok) {
+        profile = await profileRes.json()
+      } else {
+        profileRes = await fetch(`http://localhost:3000/api/profesionales/email/${encodeURIComponent(email)}`)
+        if (profileRes.ok) {
+          profile = await profileRes.json()
+          userType = 'doctor'
+        }
+      }
+
+      navigation.replace('Home', { user: profile, userType })
     } catch (err) {
       setError(err.message || 'Error de conexión, intenta nuevamente')
     } finally {

--- a/Frontend/componentes/auth/Registro.js
+++ b/Frontend/componentes/auth/Registro.js
@@ -50,7 +50,6 @@ export default function Register({ navigation }) {
 
   const handleRegister = async () => {
     setError(null)
-    
 
     if (!email || !password || !confirmPassword || !nombreCompleto) {
       setError('Por favor, completá todos los campos obligatorios.')
@@ -99,6 +98,7 @@ export default function Register({ navigation }) {
               matricula,
               id_especialidad: especialidad,
               telefono,
+              email,
             }
 
       const endpoint =
@@ -117,8 +117,16 @@ export default function Register({ navigation }) {
         throw new Error('Error al registrar usuario')
       }
 
-      alert('Registro exitoso')
-      navigation.replace('Login')
+      await supabase.auth.signInWithPassword({ email, password })
+
+      const profileEndpoint =
+        userType === 'paciente'
+          ? `http://localhost:3000/api/pacientes/usuario/${usuarioId}`
+          : `http://localhost:3000/api/profesionales/email/${encodeURIComponent(email)}`
+      const profileRes = await fetch(profileEndpoint)
+      const profile = await profileRes.json()
+
+      navigation.replace('Home', { user: profile, userType })
     } catch (err) {
       console.error(err)
       setError(err.message || 'Ocurrió un error al registrar. Intentalo de nuevo.')

--- a/Frontend/data/Supabase.js
+++ b/Frontend/data/Supabase.js
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js'
-
-const SUPABASE_URL = 'https://qhtjlctnsoajgouinjaq.supabase.co' // la URL real
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFodGpsY3Ruc29hamdvdWluamFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkwMzU2NjMsImV4cCI6MjA2NDYxMTY2M30.AVpXetLCSZLG_hg0W4wSJGVvXuwaIiwo983QZZAshI8'   // tu clave pública real
-
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)


### PR DESCRIPTION
## Summary
- Fix registration to create user record, auto-login, and redirect home with profile data
- Load user profile after login and display details on Home/Profile screens
- Add backend lookups for patients by user ID and professionals by email
- Clean up redundant code and remove unused Supabase client file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd Backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a1985eb4832ea02b2df4dc4d8782