### PR TITLE
Ensure doctor registration sends full contact info

### DIFF
--- a/Backend/repositories/profesionales-repository.js
+++ b/Backend/repositories/profesionales-repository.js
@@ -54,29 +54,32 @@ export default class ProfesionalesRepository {
 
         try {
             /*
-            INSERT INTO "public"."profesionales" 
-	("id", "nombre_completo", "matricula", "especialidad", "telefono", "id_especialidad") 
-VALUES 
-	('3', 'Pablo', '32132132', 'eliminar este ampo', '1114444', '1');
+            INSERT INTO "public"."profesionales"
+        ("id", "nombre_completo", "matricula", "email", "especialidad", "telefono", "id_especialidad")
+VALUES
+        ('3', 'Pablo', '32132132', 'pablo@test.com', 'eliminar este ampo', '1114444', '1');
             */
             const sql = ` INSERT INTO profesionales (
-                            nombre_completo         , 
-                            matricula               , 
-                 
-                            telefono                , 
+                            nombre_completo         ,
+                            matricula               ,
+                            email                   ,
+                            telefono                ,
+                            especialidad            ,
                             id_especialidad
                         ) VALUES (
-                            $1, 
-                            $2, 
-                            $3, 
-                            $4
-                     
+                            $1,
+                            $2,
+                            $3,
+                            $4,
+                            $5,
+                            $6
                         ) RETURNING id`;
-            const values =  [   entity?.nombre_completo         ?? '', 
-                                entity?.matricula               ?? '', 
-                                entity?.telefono                ?? '', 
-                                entity?.id_
-                                         ?? null
+            const values =  [   entity?.nombre_completo         ?? '',
+                                entity?.matricula               ?? '',
+                                entity?.email                   ?? '',
+                                entity?.telefono                ?? '',
+                                entity?.especialidad            ?? '',
+                                entity?.id_especialidad         ?? null
                             ];
             const resultPg = await this.getDBPool().query(sql, values);
             newId = resultPg.rows[0].id;

--- a/Frontend/componentes/auth/Registro.js
+++ b/Frontend/componentes/auth/Registro.js
@@ -61,7 +61,7 @@ export default function Register({ navigation }) {
       return
     }
 
-    if (userType === 'doctor' && (!matricula || !especialidad)) {
+    if (userType === 'doctor' && (!matricula || !especialidad || !telefono)) {
       setError('Por favor, completá todos los campos obligatorios para doctores.')
       return
     }
@@ -96,9 +96,12 @@ export default function Register({ navigation }) {
             password,
             matricula,
             especialidad,
+            telefono,
           }
-         
-      const response = await fetch('http://localhost:3000/api/profesionales', {
+
+      const endpoint = userType === 'paciente' ? 'pacientes' : 'profesionales'
+
+      const response = await fetch(`http://localhost:3000/api/${endpoint}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -177,6 +180,13 @@ export default function Register({ navigation }) {
               placeholder="Matrícula"
               value={matricula}
               onChangeText={setMatricula}
+              style={styles.input}
+            />
+            <TextInput
+              placeholder="Teléfono"
+              value={telefono}
+              onChangeText={setTelefono}
+              keyboardType="phone-pad"
               style={styles.input}
             />
             <Picker


### PR DESCRIPTION
## Summary
- Save email, phone, and specialty when creating professionals
- Include doctor phone field in registration form and send to proper backend endpoint

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd Backend && npm test)` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b1bdb9d884832ebfc77455ed21d122