### PR TITLE
Add turno confirmation API and frontend management screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,8 +7,9 @@ import Register from './Frontend/componentes/auth/Registro'
 import HomeScreen from './Frontend/componentes/Home/HomeScreen'
 import InfoScreen from './Frontend/componentes/Home/InfoScreen'
 import ProfileScreen from './Frontend/componentes/Profile/ProfileScreen'
-import WelcomeScreen from './Frontend/componentes/Home/WelcomeScreen' 
+import WelcomeScreen from './Frontend/componentes/Home/WelcomeScreen'
 import AgendarTurno from './Frontend/componentes/Home/AgendarTurno'
+import TurnosScreen from './Frontend/componentes/Home/TurnosScreen'
 
 const Stack = createNativeStackNavigator()
 
@@ -23,6 +24,7 @@ export default function App() {
         <Stack.Screen name="Info" component={InfoScreen} />
         <Stack.Screen name="Profile" component={ProfileScreen} />
         <Stack.Screen name="Agendar Turno" component={AgendarTurno}/>
+        <Stack.Screen name="Turnos" component={TurnosScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   )

--- a/Backend/controllers/turnos-controller.js
+++ b/Backend/controllers/turnos-controller.js
@@ -56,6 +56,88 @@ router.post('', async (req, res) => {
   }
 });
 
+router.put('/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const { paciente_id, profesional_id, fecha, estado } = req.body;
+
+  if (Number.isNaN(id)) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      ok: false,
+      message: 'El identificador del turno es inválido.',
+    });
+  }
+
+  if (
+    paciente_id === undefined &&
+    profesional_id === undefined &&
+    fecha === undefined &&
+    estado === undefined
+  ) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      ok: false,
+      message: 'No se enviaron campos para actualizar.',
+    });
+  }
+
+  const allowedEstados = ['P', 'C', 'R'];
+  if (estado !== undefined && !allowedEstados.includes(estado)) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      ok: false,
+      message: `El estado "${estado}" no es válido. Valores permitidos: ${allowedEstados.join(', ')}`,
+    });
+  }
+
+  try {
+    const entity = { id, paciente_id, profesional_id, fecha, estado };
+    const updatedEntity = await currentService.updateAsync(entity);
+    if (updatedEntity != null) {
+      return res.status(StatusCodes.OK).json({
+        ok: true,
+        turno: updatedEntity,
+      });
+    }
+    return res.status(StatusCodes.NOT_FOUND).json({
+      ok: false,
+      message: `No se encontró el turno (id:${id}).`,
+    });
+  } catch (error) {
+    console.error(error);
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ ok: false, message: 'Error interno del servidor' });
+  }
+});
+
+router.put('/:id/confirmar', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+
+  if (Number.isNaN(id)) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      ok: false,
+      message: 'El identificador del turno es inválido.',
+    });
+  }
+
+  try {
+    const updatedEntity = await currentService.confirmarAsync(id);
+    if (updatedEntity != null) {
+      return res.status(StatusCodes.OK).json({
+        ok: true,
+        turno: updatedEntity,
+      });
+    }
+    return res.status(StatusCodes.NOT_FOUND).json({
+      ok: false,
+      message: `No se encontró el turno (id:${id}).`,
+    });
+  } catch (error) {
+    console.error(error);
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ ok: false, message: 'Error interno del servidor' });
+  }
+});
+
 router.delete('/:id', async (req, res) => {
   const id = req.params.id;
   try {

--- a/Backend/repositories/turnos-repository.js
+++ b/Backend/repositories/turnos-repository.js
@@ -1,156 +1,157 @@
-import pkg          from 'pg'
-import config       from './../configs/db-config.js';      // Traigo la configuracion de la base de datos.
-import LogHelper    from './../helpers/log-helper.js'
+import pkg from 'pg';
+import config from './../configs/db-config.js';
+import LogHelper from './../helpers/log-helper.js';
 
-const { Pool }  = pkg;
+const { Pool } = pkg;
 
 export default class TurnosRepository {
-    constructor() {
-        // Se ejecuta siempre, (al instanciar la clase)
-        console.log('TurnosRepository.constructor()');
-        this.DBPool     = null;
+  constructor() {
+    console.log('TurnosRepository.constructor()');
+    this.DBPool = null;
+  }
+
+  getDBPool = () => {
+    if (this.DBPool == null) {
+      this.DBPool = new Pool(config);
+    }
+    return this.DBPool;
+  };
+
+  getAllAsync = async () => {
+    console.log('TurnosRepository.getAllAsync()');
+    let returnArray = null;
+
+    try {
+      const sql = 'SELECT * FROM turnos ORDER BY fecha DESC';
+      const resultPg = await this.getDBPool().query(sql);
+      returnArray = resultPg.rows;
+    } catch (error) {
+      LogHelper.logError(error);
+    }
+    return returnArray;
+  };
+
+  getByIdAsync = async (id) => {
+    console.log(`TurnosRepository.getByIdAsync(${id})`);
+    let returnEntity = null;
+    try {
+      const sql = 'SELECT * FROM turnos WHERE id=$1';
+      const values = [id];
+      const resultPg = await this.getDBPool().query(sql, values);
+      if (resultPg.rows.length > 0) {
+        returnEntity = resultPg.rows[0];
+      }
+    } catch (error) {
+      LogHelper.logError(error);
+    }
+    return returnEntity;
+  };
+
+  createAsync = async (entity) => {
+    let newId = 0;
+    try {
+      const sql = `
+        INSERT INTO turnos (
+          paciente_id,
+          profesional_id,
+          fecha,
+          creado_el
+        ) VALUES ($1, $2, $3, $4)
+        RETURNING id
+      `;
+
+      const values = [
+        entity.paciente_id,
+        entity.profesional_id,
+        entity.fecha,
+        new Date(),
+      ];
+
+      const resultPg = await this.getDBPool().query(sql, values);
+      newId = resultPg.rows[0].id;
+    } catch (error) {
+      LogHelper.logError(error);
+    }
+    return newId;
+  };
+
+  updateAsync = async (entity) => {
+    console.log(`TurnosRepository.updateAsync(${JSON.stringify(entity)})`);
+    let updatedEntity = null;
+    const id = entity.id;
+
+    if (!id) {
+      return null;
     }
 
-    getDBPool = () => {
-        if (this.DBPool == null){
-            this.DBPool = new Pool(config);
-        }
-        return this.DBPool;
+    try {
+      const previousEntity = await this.getByIdAsync(id);
+      if (previousEntity == null) return null;
+
+      const sql = `
+        UPDATE turnos SET
+          paciente_id = $2,
+          profesional_id = $3,
+          fecha = $4,
+          estado = COALESCE($5, estado)
+        WHERE id = $1
+        RETURNING *
+      `;
+
+      const values = [
+        id,
+        entity?.paciente_id ?? previousEntity?.paciente_id,
+        entity?.profesional_id ?? previousEntity?.profesional_id,
+        entity?.fecha ?? previousEntity?.fecha,
+        entity?.estado ?? previousEntity?.estado ?? null,
+      ];
+
+      const resultPg = await this.getDBPool().query(sql, values);
+      if (resultPg.rows.length > 0) {
+        updatedEntity = resultPg.rows[0];
+      }
+    } catch (error) {
+      LogHelper.logError(error);
+    }
+    return updatedEntity;
+  };
+
+  updateEstadoAsync = async (id, estado) => {
+    console.log(`TurnosRepository.updateEstadoAsync(${id}, ${estado})`);
+    let updatedEntity = null;
+
+    try {
+      const sql = `
+        UPDATE turnos SET
+          estado = $2
+        WHERE id = $1
+        RETURNING *
+      `;
+
+      const values = [id, estado];
+      const resultPg = await this.getDBPool().query(sql, values);
+      if (resultPg.rows.length > 0) {
+        updatedEntity = resultPg.rows[0];
+      }
+    } catch (error) {
+      LogHelper.logError(error);
     }
 
-    getAllAsync = async () => {
-        console.log(`TurnosRepository.getAllAsync()`);
-        let returnArray = null;
-        
-        try {
-            const sql = `SELECT * FROM Turnos`;
-            const resultPg = await this.getDBPool().query(sql);
-            returnArray = resultPg.rows;
-        } catch (error) {
-            LogHelper.logError(error);
-        }
-        return returnArray;
-    }
+    return updatedEntity;
+  };
 
-    getByIdAsync = async (id) => {
-        console.log(`TurnosRepository.getByIdAsync(${id})`);
-        let returnEntity = null;
-        try {
-            const sql = `SELECT * FROM Turnos WHERE id=$1`;
-            const values = [id];
-            const resultPg = await this.getDBPool().query(sql, values);
-            if (resultPg.rows.length > 0){
-                returnEntity = resultPg.rows[0];
-            }
-        } catch (error) {
-            LogHelper.logError(error);
-        } 
-        return returnEntity;
-    }
+  deleteByIdAsync = async (id) => {
+    console.log(`TurnosRepository.deleteByIdAsync(${id})`);
+    let rowsAffected = 0;
 
-    createAsync = async (entity) => {
-        let newId = 0;
-        try {
-            const sql = `
-                INSERT INTO turnos (
-                    paciente_id, 
-                    profesional_id, 
-                    fecha, 
-                    creado_el
-                ) VALUES ($1, $2, $3, $4)
-                RETURNING id
-            `;
-    
-            const values = [
-                entity.paciente_id,
-                entity.profesional_id,
-                entity.fecha,
-                new Date()
-            ];
-    
-            const resultPg = await this.getDBPool().query(sql, values);
-            newId = resultPg.rows[0].id;
-        } catch (error) {
-            console.error(error);
-        }
-        return newId;
+    try {
+      const sql = 'DELETE FROM turnos WHERE id=$1';
+      const values = [id];
+      const resultPg = await this.getDBPool().query(sql, values);
+      rowsAffected = resultPg.rowCount;
+    } catch (error) {
+      LogHelper.logError(error);
     }
-    
-    
-/*
-    updateAsync = async (entity) => {
-        console.log(`TurnosRepository.updateAsync(${JSON.stringify(entity)})`);
-        let rowsAffected = 0;
-        let id = entity.id;
-        
-        try {
-            const previousEntity = await this.getByIdAsync(id);
-            if (previousEntity== null) return 0;
-            const sql = `UPDATE Turnos SET 
-                            paciente_id         = $3, 
-                            profecional_id      = $4, 
-                            fecha               = $5, 
-                            creado_el           = $6
-                        WHERE id = $1`;
-                            
-            const values =  [   id,     // $1
-                                entity?.nombre              ?? previousEntity?.nombre, 
-                                entity?.apellido            ?? previousEntity?.apellido, 
-                                entity?.id_curso            ?? previousEntity?.id_curso, 
-                                entity?.fecha_nacimiento    ?? previousEntity?.fecha_nacimiento, 
-                                entity?.hace_deportes       ?? previousEntity?.hace_deportes
-                            ];
-            const resultPg = await this.getDBPool().query(sql, values);
-
-            rowsAffected = resultPg.rowCount;
-        } catch (error) {
-            LogHelper.logError(error);
-        }
-        return rowsAffected;
-    }
-    
-    deleteByIdAsync = async (id) => {
-        console.log(`TurnosRepository.deleteByIdAsync(${id})`);
-        let rowsAffected = 0;
-        
-        try {
-            const sql = `DELETE from Turnos WHERE id=$1`;
-            const values = [id];
-            const resultPg = await this.getDBPool().query(sql, values);
-            rowsAffected = resultPg.rowCount;
-        } catch (error) {
-            LogHelper.logError(error);
-        }
-        return rowsAffected;
-    }
+    return rowsAffected;
+  };
 }
-/*
-Este operador (??) retorna el lado derecho de la operación cuando el lado izquierdo es un valor falsy.
-
-falsy es un valor que se considera false (false). 
-En Javascript existen sólo 6 valores falsy: undefined, null, NaN, 0, "" (string vacio) y false.
-
-console.log(12 || "not found") // 12
-console.log(0  || "not found") // "not found"
-
-console.log("jane" || "not found") // "jane"
-console.log(""     || "not found") // "not found"
-
-console.log(true  || "not found") // true
-console.log(false || "not found") // "not found"
-
-console.log(undefined || "not found") // "not found"
-console.log(null      || "not found") // "not found"
-----------------------------------------------------
-console.log(12 ?? "not found") // 12
-console.log(0  ?? "not found") // 0
-
-console.log("jane" ?? "not found") // "jane"
-console.log(""     ?? "not found") // ""
-
-console.log(true  ?? "not found") // true
-console.log(false ?? "not found") // false
-
-console.log(undefined ?? "not found") // "not found"
-console.log(null      ?? "not found") // "not found"
-*/}

--- a/Backend/services/turnos-service.js
+++ b/Backend/services/turnos-service.js
@@ -23,13 +23,18 @@ export default class TurnosService {
         const rowsAffected = await this.TurnosRepository.createAsync(entity);
         return rowsAffected;
     }
-    /*  
+
     updateAsync = async (entity) => {
         console.log(`TurnosService.updateAsync(${JSON.stringify(entity)})`);
-        const rowsAffected = await this.TurnosRepository.updateAsync(entity);
-        return rowsAffected;
+        const updatedEntity = await this.TurnosRepository.updateAsync(entity);
+        return updatedEntity;
     }
-    */    
+
+    confirmarAsync = async (id) => {
+        console.log(`TurnosService.confirmarAsync(${id})`);
+        const updatedEntity = await this.TurnosRepository.updateEstadoAsync(id, 'C');
+        return updatedEntity;
+    }
     deleteByIdAsync = async (id) => {
         console.log(`TurnosService.deleteByIdAsync(${id})`);
         const rowsAffected = await this.TurnosRepository.deleteByIdAsync(id);

--- a/Frontend/componentes/Home/HomeScreen.js
+++ b/Frontend/componentes/Home/HomeScreen.js
@@ -21,6 +21,10 @@ export default function HomeScreen({ navigation }) {
         <Text style={styles.buttonText}>Mi Perfil</Text>
       </TouchableOpacity>
 
+      <TouchableOpacity style={styles.secondaryButton} onPress={() => navigation.navigate('Turnos')}>
+        <Text style={styles.secondaryButtonText}>Gestionar turnos</Text>
+      </TouchableOpacity>
+
       <TouchableOpacity style={[styles.button, {backgroundColor: '#e74c3c'}]} onPress={handleLogout}>
         <Text style={styles.buttonText}>Cerrar sesión</Text>
       </TouchableOpacity>
@@ -32,6 +36,8 @@ const styles = StyleSheet.create({
   container: { flex:1, justifyContent:'center', alignItems:'center', backgroundColor:'#fff', padding:20 },
   title: { fontSize:28, fontWeight:'bold', marginBottom:10, color:'#1A1A6E' },
   subtitle: { fontSize:16, marginBottom:30, color:'#555' },
-  button: { width:'100%', height:50, backgroundColor:'#1A1A6E', borderRadius:10, justifyContent:'center', alignItems:'center', marginVertical:10 },
-  buttonText: { color:'#fff', fontSize:18, fontWeight:'bold' }
+  button: { width:'100%', height:50, backgroundColor:'#1A1A6E', borderRadius:12, justifyContent:'center', alignItems:'center', marginVertical:8 },
+  buttonText: { color:'#fff', fontSize:18, fontWeight:'bold' },
+  secondaryButton: { width:'100%', height:50, backgroundColor:'#2A9D8F', borderRadius:12, justifyContent:'center', alignItems:'center', marginVertical:8 },
+  secondaryButtonText: { color:'#fff', fontSize:18, fontWeight:'bold' }
 })

--- a/Frontend/componentes/Home/TurnosScreen.js
+++ b/Frontend/componentes/Home/TurnosScreen.js
@@ -1,0 +1,325 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { TURNOS_ENDPOINT } from '../../utils/apiConfig';
+
+const ESTADO_LABELS = {
+  P: 'Pendiente',
+  C: 'Confirmado',
+  R: 'Rechazado',
+};
+
+const ESTADO_COLORS = {
+  P: '#F4A261',
+  C: '#2A9D8F',
+  R: '#E76F51',
+};
+
+const formatFecha = (fechaIso) => {
+  if (!fechaIso) return 'Sin fecha';
+  try {
+    const fecha = new Date(fechaIso);
+    const fechaLocal = fecha.toLocaleDateString();
+    const horaLocal = fecha.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${fechaLocal} · ${horaLocal}`;
+  } catch (error) {
+    return fechaIso;
+  }
+};
+
+const TurnosScreen = () => {
+  const [turnos, setTurnos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+  const [confirmingId, setConfirmingId] = useState(null);
+
+  const fetchTurnos = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await fetch(TURNOS_ENDPOINT);
+      if (!response.ok) {
+        throw new Error('No se pudieron obtener los turnos.');
+      }
+      const data = await response.json();
+      setTurnos(Array.isArray(data) ? data : []);
+    } catch (fetchError) {
+      console.error(fetchError);
+      setError(fetchError.message);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTurnos();
+  }, [fetchTurnos]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchTurnos();
+  }, [fetchTurnos]);
+
+  const confirmTurno = useCallback(
+    async (turnoId) => {
+      setConfirmingId(turnoId);
+      try {
+        const response = await fetch(`${TURNOS_ENDPOINT}/${turnoId}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ estado: 'C' }),
+        });
+
+        const payload = await response.json();
+        if (!response.ok || !payload?.ok) {
+          throw new Error(payload?.message ?? 'No se pudo confirmar el turno.');
+        }
+
+        setTurnos((prev) =>
+          prev.map((turno) => (turno.id === turnoId ? payload.turno : turno))
+        );
+
+        Alert.alert('Turno confirmado', 'El turno fue confirmado correctamente.');
+      } catch (confirmError) {
+        console.error(confirmError);
+        Alert.alert('Error', confirmError.message);
+      } finally {
+        setConfirmingId(null);
+      }
+    },
+    []
+  );
+
+  const contenido = useMemo(() => {
+    if (loading) {
+      return (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#1A1A6E" />
+          <Text style={styles.loadingText}>Cargando turnos...</Text>
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View style={styles.centered}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.secondaryButton} onPress={fetchTurnos}>
+            <Text style={styles.secondaryButtonText}>Reintentar</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    if (turnos.length === 0) {
+      return (
+        <View style={styles.centered}>
+          <Text style={styles.emptyTitle}>No hay turnos agendados</Text>
+          <Text style={styles.emptySubtitle}>
+            Cuando agendes nuevos turnos vas a poder verlos y confirmarlos desde aquí.
+          </Text>
+        </View>
+      );
+    }
+
+    return (
+      <FlatList
+        data={turnos}
+        keyExtractor={(item) => item.id?.toString() ?? Math.random().toString()}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#1A1A6E" />
+        }
+        renderItem={({ item }) => {
+          const estadoLabel = ESTADO_LABELS[item.estado] ?? 'Sin estado';
+          const estadoColor = ESTADO_COLORS[item.estado] ?? '#1A1A6E';
+          const estaConfirmado = item.estado === 'C';
+
+          return (
+            <View style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>Turno #{item.id}</Text>
+                <View style={[styles.badge, { backgroundColor: estadoColor }]}>
+                  <Text style={styles.badgeText}>{estadoLabel}</Text>
+                </View>
+              </View>
+              <Text style={styles.cardItem}>
+                <Text style={styles.cardLabel}>Paciente: </Text>
+                {item.paciente_id ?? 'Sin asignar'}
+              </Text>
+              <Text style={styles.cardItem}>
+                <Text style={styles.cardLabel}>Profesional: </Text>
+                {item.profesional_id ?? 'Sin asignar'}
+              </Text>
+              <Text style={styles.cardItem}>
+                <Text style={styles.cardLabel}>Fecha: </Text>
+                {formatFecha(item.fecha)}
+              </Text>
+
+              {!estaConfirmado && (
+                <TouchableOpacity
+                  style={styles.confirmButton}
+                  onPress={() => confirmTurno(item.id)}
+                  disabled={confirmingId === item.id}
+                >
+                  {confirmingId === item.id ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text style={styles.confirmButtonText}>Confirmar turno</Text>
+                  )}
+                </TouchableOpacity>
+              )}
+            </View>
+          );
+        }}
+      />
+    );
+  }, [confirmTurno, confirmingId, error, loading, onRefresh, refreshing, turnos, fetchTurnos]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Gestión de turnos</Text>
+        <Text style={styles.subtitle}>
+          Revisá los turnos de tus pacientes y confirmalos cuando corresponda.
+        </Text>
+      </View>
+      {contenido}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F6F8FB',
+    paddingHorizontal: 20,
+    paddingTop: 50,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: 'bold',
+    color: '#1A1A6E',
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#5F6B7D',
+    lineHeight: 20,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 30,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#1A1A6E',
+    fontWeight: '500',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#E76F51',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  secondaryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#1A1A6E',
+  },
+  secondaryButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1A1A6E',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#5F6B7D',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  listContent: {
+    paddingBottom: 40,
+  },
+  card: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 20,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 4,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1A1A6E',
+  },
+  badge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+  },
+  badgeText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 12,
+    textTransform: 'uppercase',
+  },
+  cardItem: {
+    fontSize: 15,
+    color: '#3E4A59',
+    marginBottom: 6,
+  },
+  cardLabel: {
+    fontWeight: '700',
+    color: '#1A1A6E',
+  },
+  confirmButton: {
+    marginTop: 14,
+    height: 48,
+    borderRadius: 16,
+    backgroundColor: '#2A9D8F',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  confirmButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});
+
+export default TurnosScreen;

--- a/Frontend/utils/apiConfig.js
+++ b/Frontend/utils/apiConfig.js
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native';
+
+const getLocalhost = () => {
+  if (Platform.OS === 'android') {
+    return '10.0.2.2';
+  }
+  return 'localhost';
+};
+
+const baseHost = getLocalhost();
+
+const expoApiUrl =
+  typeof process !== 'undefined' && process?.env?.EXPO_PUBLIC_API_URL
+    ? process.env.EXPO_PUBLIC_API_URL.replace(/\/$/, '')
+    : undefined;
+
+export const API_BASE_URL = expoApiUrl ?? `http://${baseHost}:3000/api`;
+
+export const TURNOS_ENDPOINT = `${API_BASE_URL}/turnos`;


### PR DESCRIPTION
## Summary
- implement turno update and confirmation endpoints with validation and repository support
- add API config helpers for the frontend and expose a new turnos management screen matching MedUp styling
- wire the home navigation to the new screen so doctors can confirm appointments from the app

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da74ebe5d0832e9087ff40451a9e8d